### PR TITLE
Segment the results into a test-suite per Python module

### DIFF
--- a/pytest_nunit/nunit.py
+++ b/pytest_nunit/nunit.py
@@ -224,11 +224,9 @@ class NunitTestRun(object):
                 result=TestStatusType.Passed,  # TODO: Determine suite status
                 label=self.nunitxml.module_descriptions[nodeid],
                 site=None,
-                start_time=self.nunitxml.suite_start_time.strftime(  # TODO: Determine suite-level times
-                    "%Y-%m-%d %H:%M:%S.%f"
-                ),
-                end_time=self.nunitxml.suite_stop_time.strftime("%Y-%m-%d %H:%M:%S.%f"),
-                duration=self.nunitxml.suite_time_delta,
+                start_time=module.start.strftime("%Y-%m-%d %H:%M:%S.%f"),
+                end_time=module.stop.strftime("%Y-%m-%d %H:%M:%S.%f"),
+                duration=module.duration,
                 asserts=module.stats["asserts"],
                 total=module.stats["total"],
                 passed=module.stats["passed"],

--- a/pytest_nunit/nunit.py
+++ b/pytest_nunit/nunit.py
@@ -139,6 +139,7 @@ class NunitTestRun(object):
     def __init__(self, nunitxml):
         self.nunitxml = nunitxml
 
+
     @property
     def environment(self):
         return EnvironmentType(
@@ -155,8 +156,7 @@ class NunitTestRun(object):
             os_architecture=platform.architecture()[0],
         )
 
-    @property
-    def test_cases(self):
+    def test_cases(self, module):
         return [
             TestCaseElementType(
                 id_=str(case["idref"]),
@@ -194,16 +194,16 @@ class NunitTestRun(object):
                 duration=case["duration"],
                 asserts=0,  # TODO : Add assert count
             )
-            for nodeid, case in self.nunitxml.cases.items()
+            for nodeid, case in self.nunitxml.modules[module].cases.items()
         ]
 
     @property
     def test_suites(self):
         return [
             TestSuiteElementType(
-                id_="3",  # TODO : Suite numbers
-                name=self.nunitxml.suite_name,
-                fullname="pytest",
+                id_=nodeid,
+                name=nodeid,
+                fullname=nodeid,
                 methodname="",
                 classname="",
                 test_suite=None,
@@ -217,26 +217,27 @@ class NunitTestRun(object):
                 output=None,
                 assertions=None,
                 attachments=None,
-                test_case=self.test_cases,
+                test_case=self.test_cases(nodeid),
                 runstate=TestRunStateType.Runnable,
                 type_=TestSuiteTypeType.Assembly,
-                testcasecount=self.nunitxml.stats["total"],
-                result=TestStatusType.Passed,
-                label="",
+                testcasecount=module.stats["total"],
+                result=TestStatusType.Passed,  # TODO: Determine suite status
+                label=self.nunitxml.module_descriptions[nodeid],
                 site=None,
-                start_time=self.nunitxml.suite_start_time.strftime(
+                start_time=self.nunitxml.suite_start_time.strftime(  # TODO: Determine suite-level times
                     "%Y-%m-%d %H:%M:%S.%f"
                 ),
                 end_time=self.nunitxml.suite_stop_time.strftime("%Y-%m-%d %H:%M:%S.%f"),
                 duration=self.nunitxml.suite_time_delta,
-                asserts=self.nunitxml.stats["asserts"],
-                total=self.nunitxml.stats["total"],
-                passed=self.nunitxml.stats["passed"],
-                failed=self.nunitxml.stats["failure"],
+                asserts=module.stats["asserts"],
+                total=module.stats["total"],
+                passed=module.stats["passed"],
+                failed=module.stats["failure"],
                 warnings=0,
                 inconclusive=0,
-                skipped=self.nunitxml.stats["skipped"],
+                skipped=module.stats["skipped"],
             )
+            for nodeid, module in self.nunitxml.modules.items()
         ]
 
     def as_test_run(self):

--- a/pytest_nunit/plugin.py
+++ b/pytest_nunit/plugin.py
@@ -24,6 +24,8 @@ log = logging.getLogger("__name__")
 
 
 PytestFilters = namedtuple("PytestFilters", "keyword markers file_or_dir")
+ModuleReport = namedtuple("ModuleReport", "stats cases")
+ParentlessNode = 'PARENTLESS_NODE'
 
 
 def pytest_addoption(parser):
@@ -101,10 +103,6 @@ class _NunitNodeReporter:
     def __init__(self, nodeid, nunit_xml):
         self.id = nodeid
         self.nunit_xml = nunit_xml
-
-    def append(self, node):
-        self.nunit_xml.add_stats(type(node).__name__)
-        self.nodes.append(node)
 
     def record_testreport(self, testreport):
         log.debug("record_test_report:{0}".format(testreport))
@@ -245,6 +243,8 @@ class NunitXML:
 
         self.node_descriptions = defaultdict(str)
         self.module_descriptions = defaultdict(str)
+        self.node_to_module_map = {}
+        self.modules = {}
 
     def finalize(self, report):
         nodeid = getattr(report, "nodeid", report)
@@ -304,6 +304,11 @@ class NunitXML:
             if item.obj:
                 self.node_descriptions[item.nodeid] = item.obj.__doc__
 
+            if item.parent:
+                self.node_to_module_map[item.nodeid] = item.parent.nodeid
+            else:  # A parent-less node could happen with some custom test-collection plugins.
+                self.node_to_module_map[item.nodeid] = ParentlessNode
+
     def pytest_sessionfinish(self, session, *args):
         # Build output file
         dirname = os.path.dirname(os.path.abspath(self.logfile))
@@ -324,6 +329,24 @@ class NunitXML:
         self.stats["skipped"] = len(
             list(case for case in self.cases.values() if case["outcome"] == "skipped")
         )
+
+        # Sort nodes into modules
+        for module_id in set(self.node_to_module_map.values()):
+            cases = {nodeid: self.cases[nodeid] for nodeid, m_id in self.node_to_module_map.items() if module_id == m_id}
+            stats = dict.fromkeys(
+                ["error", "passed", "failure", "skipped", "total", "asserts"], 0
+            )
+            stats["total"] = len(cases)
+            stats["passed"] = len(
+                list(case for case in cases.values() if case["outcome"] == "passed")
+            )
+            stats["failure"] = len(
+                list(case for case in cases.values() if case["outcome"] == "failed")
+            )
+            stats["skipped"] = len(
+                list(case for case in cases.values() if case["outcome"] == "skipped")
+            )
+            self.modules[module_id] = ModuleReport(stats=stats, cases=cases)
 
         with open(self.logfile, "w", encoding="utf-8") as logfile:
             result = NunitTestRun(self).generate_xml()

--- a/pytest_nunit/plugin.py
+++ b/pytest_nunit/plugin.py
@@ -24,7 +24,7 @@ log = logging.getLogger("__name__")
 
 
 PytestFilters = namedtuple("PytestFilters", "keyword markers file_or_dir")
-ModuleReport = namedtuple("ModuleReport", "stats cases")
+ModuleReport = namedtuple("ModuleReport", "stats cases start stop duration")
 ParentlessNode = 'PARENTLESS_NODE'
 
 
@@ -300,9 +300,11 @@ class NunitXML:
     def pytest_collection_modifyitems(self, session, config, items, *args):
         for item in items:
             if item.parent and item.parent.obj:
-                self.module_descriptions[item.parent.nodeid] = item.parent.obj.__doc__
+                doc = item.parent.obj.__doc__.strip() if item.parent.obj.__doc__ else ''
+                self.module_descriptions[item.parent.nodeid] = doc
             if item.obj:
-                self.node_descriptions[item.nodeid] = item.obj.__doc__
+                doc = item.obj.__doc__.strip() if item.obj.__doc__ else ''
+                self.node_descriptions[item.nodeid] = doc
 
             if item.parent:
                 self.node_to_module_map[item.nodeid] = item.parent.nodeid
@@ -346,7 +348,10 @@ class NunitXML:
             stats["skipped"] = len(
                 list(case for case in cases.values() if case["outcome"] == "skipped")
             )
-            self.modules[module_id] = ModuleReport(stats=stats, cases=cases)
+            start = min([case["start"] for case in cases.values()])
+            stop = max([case["stop"] for case in cases.values()])
+            duration = (stop - start).total_seconds()
+            self.modules[module_id] = ModuleReport(stats=stats, cases=cases, start=start, stop=stop, duration=duration)
 
         with open(self.logfile, "w", encoding="utf-8") as logfile:
             result = NunitTestRun(self).generate_xml()

--- a/tests/integration/test_properties.py
+++ b/tests/integration/test_properties.py
@@ -287,6 +287,7 @@ def test_slow_test(testdir, tmpdir):
 def test_docstring(testdir, tmpdir):
     testdir.makepyfile(
         """
+        '''Module description'''
         def test_docstring(record_nunit_property):
             '''Hello'''
             record_nunit_property("test", "value")
@@ -316,6 +317,7 @@ def test_docstring(testdir, tmpdir):
     assert out["test-suite"]["@passed"] == 1
     assert out["test-suite"]["@failed"] == 0
     assert out["test-suite"]["@skipped"] == 0
+    assert out["test-suite"]["@label"] == "Module description"
     assert out["test-suite"]["test-case"]["@label"] == "Hello"
 
 
@@ -350,4 +352,5 @@ def test_no_docstring(testdir, tmpdir):
     assert out["test-suite"]["@passed"] == 1
     assert out["test-suite"]["@failed"] == 0
     assert out["test-suite"]["@skipped"] == 0
-    assert "@label" not in out["test-suite"]["test-case"]
+    assert out["test-suite"]["@label"] == ""
+    assert out["test-suite"]["test-case"]["@label"] == ""


### PR DESCRIPTION
Has been on the backlog since day 1, but implement a per-module testsuite element and only show the test cases for that module.

Also, implement timing data for each module