### PR TITLE
Remove `logging.basicConfig()` call, use proper logging name

### DIFF
--- a/pytest_nunit/plugin.py
+++ b/pytest_nunit/plugin.py
@@ -19,8 +19,7 @@ from .nunit import NunitTestRun
 import logging
 import pytest
 
-logging.basicConfig()
-log = logging.getLogger("__name__")
+log = logging.getLogger(__name__)
 
 
 PytestFilters = namedtuple("PytestFilters", "keyword markers file_or_dir")


### PR DESCRIPTION
Fixes #52