### PR TITLE
Add user_properties to test case report

### DIFF
--- a/pytest_nunit/plugin.py
+++ b/pytest_nunit/plugin.py
@@ -165,6 +165,7 @@ class _NunitNodeReporter:
             r["call-report"] = testreport
             r["error"] = testreport.longreprtext
             r["stack-trace"] = self.nunit_xml._getcrashline(testreport)
+            r["properties"].update(testreport.user_properties)
         elif testreport.when == "teardown":
             r = self.nunit_xml.cases[testreport.nodeid]
             r["stop"] = datetime.utcnow()
@@ -390,7 +391,7 @@ class NunitXML:
         full_report = self._create_module_report(self.cases)
         self.stats.update(full_report.stats)
 
-        # pytest-xdist collection is done on workers, 
+        # pytest-xdist collection is done on workers,
         # so node_to_module_map is empty
         if not self.node_to_module_map and self.cases:
             for case_name, case in self.cases.items():


### PR DESCRIPTION
instead of creating a new API for adding properties, capture pytest user_properties.  This removes the need for a special fixture and also works correctly with pytest-parallel

Setting internal variables with the record_nunit_property is non-functional in pytest-parallel as the modifications are done in a different process (nunit_xml is a sub-process copy, so the changes are lost).  user_properties are reported and re-synchronized with the main process via the test_report.  This is a better location for test case properties IMHO.