### PR TITLE
Fix crash when ExceptionReprGroup is set for trace in test case

### DIFF
--- a/pytest_nunit/nunit.py
+++ b/pytest_nunit/nunit.py
@@ -22,6 +22,8 @@ from .models.nunit import (
     ValueMatchFilterType,
 )
 from .attrs2xml import AttrsXmlRenderer, CdataComment
+from _pytest._code.code import ExceptionChainRepr
+
 
 FRAMEWORK_VERSION = "3.6.2"  # Nunit version this was based on
 CLR_VERSION = sys.version
@@ -171,8 +173,12 @@ class NunitTestRun(object):
                 environment=self.environment,
                 settings=None,  # TODO : Add settings as optional fixture
                 failure=FailureType(
-                    message=CdataComment(text=case["error"]),
-                    stack_trace=CdataComment(text=case["stack-trace"]),
+                    message=CdataComment(text=str(case["error"])
+                    if isinstance(case["error"], ExceptionChainRepr)
+                    else case["error"]),
+                    stack_trace=CdataComment(text=str(case["error"].reprcrash)
+                    if isinstance(case["error"], ExceptionChainRepr)
+                    else case["stack-trace"])
                 ),
                 reason=ReasonType(message=CdataComment(text=case["reason"])),
                 output=CdataComment(text=case["reason"]),

--- a/pytest_nunit/nunit.py
+++ b/pytest_nunit/nunit.py
@@ -175,8 +175,6 @@ class NunitTestRun(object):
                 failure=FailureType(
                     message=CdataComment(
                         text=str(case["error"])
-                        if isinstance(case["error"], ExceptionChainRepr)
-                        else case["error"]
                     ),
                     stack_trace=CdataComment(
                         text=str(case["error"].reprcrash)

--- a/pytest_nunit/nunit.py
+++ b/pytest_nunit/nunit.py
@@ -64,7 +64,7 @@ def _format_attachments(case, attach_on):
 
     :param case: The test case
     :type  case: :class:`pytest.TestCase`
-    
+
     :param attach_on: Attach-on criteria, one of any|pass|fail
     :type  attach_on: ``str``
 
@@ -173,12 +173,16 @@ class NunitTestRun(object):
                 environment=self.environment,
                 settings=None,  # TODO : Add settings as optional fixture
                 failure=FailureType(
-                    message=CdataComment(text=str(case["error"])
-                    if isinstance(case["error"], ExceptionChainRepr)
-                    else case["error"]),
-                    stack_trace=CdataComment(text=str(case["error"].reprcrash)
-                    if isinstance(case["error"], ExceptionChainRepr)
-                    else case["stack-trace"])
+                    message=CdataComment(
+                        text=str(case["error"])
+                        if isinstance(case["error"], ExceptionChainRepr)
+                        else case["error"]
+                    ),
+                    stack_trace=CdataComment(
+                        text=str(case["error"].reprcrash)
+                        if isinstance(case["error"], ExceptionChainRepr)
+                        else case["stack-trace"]
+                    ),
                 ),
                 reason=ReasonType(message=CdataComment(text=case["reason"])),
                 output=CdataComment(text=case["reason"]),

--- a/tests/integration/test_tests.py
+++ b/tests/integration/test_tests.py
@@ -211,6 +211,6 @@ def test_failing_fixture(testdir, tmpdir):
     outfile_pth = str(outfile)
 
     result = testdir.runpytest("-v", "--nunit-xml=" + outfile_pth)
-    assert result.ret == 0
+    assert int(result.ret) == 0
     result.stdout.fnmatch_lines(["*test_one PASSED*"])
     result.stdout.fnmatch_lines(["*test_two PASSED*"])

--- a/tests/integration/test_tests.py
+++ b/tests/integration/test_tests.py
@@ -211,6 +211,7 @@ def test_failing_fixture(testdir, tmpdir):
     outfile_pth = str(outfile)
 
     result = testdir.runpytest("-v", "--nunit-xml=" + outfile_pth)
-    assert int(result.ret) == 0
-    result.stdout.fnmatch_lines(["*test_one PASSED*"])
-    result.stdout.fnmatch_lines(["*test_two PASSED*"])
+    assert int(result.ret) == 1
+    assert "".join(result.stderr.lines) == ''
+    result.stdout.fnmatch_lines(["*test_one ERROR*"])
+    result.stdout.fnmatch_lines(["*test_two XFAIL*"])

--- a/tests/integration/test_tests.py
+++ b/tests/integration/test_tests.py
@@ -188,3 +188,29 @@ def test_error_test(testdir, tmpdir):
     assert out["test-suite"]["@passed"] == 0
     assert out["test-suite"]["@failed"] == 1
     assert out["test-suite"]["@skipped"] == 0
+
+
+def test_failing_fixture(testdir, tmpdir):
+    testdir.makepyfile("""
+    import pytest
+    
+    @pytest.fixture(scope="class")
+    def failing_fixture():
+        raise Exception("SomeException")
+    
+    @pytest.mark.usefixtures("failing_fixture")
+    class TestOne:
+        def test_one(self):
+            pass
+    
+        @pytest.mark.xfail(reason="No reason")
+        def test_two(self):
+            pytest.fail()
+    """)
+    outfile = tmpdir.join("out.xml")
+    outfile_pth = str(outfile)
+
+    result = testdir.runpytest("-v", "--nunit-xml=" + outfile_pth)
+    assert result.ret == 0
+    result.stdout.fnmatch_lines(["*test_one PASSED*"])
+    result.stdout.fnmatch_lines(["*test_two PASSED*"])

--- a/tests/integration/test_tests.py
+++ b/tests/integration/test_tests.py
@@ -191,7 +191,12 @@ def test_error_test(testdir, tmpdir):
 
 
 def test_failing_fixture(testdir, tmpdir):
-    testdir.makepyfile("""
+    """
+    Test resolving issue # 55
+    https://github.com/pytest-dev/pytest-nunit/issues/55
+    """
+    testdir.makepyfile(
+        """
     import pytest
     
     @pytest.fixture(scope="class")
@@ -206,12 +211,13 @@ def test_failing_fixture(testdir, tmpdir):
         @pytest.mark.xfail(reason="No reason")
         def test_two(self):
             pytest.fail()
-    """)
+    """
+    )
     outfile = tmpdir.join("out.xml")
     outfile_pth = str(outfile)
 
     result = testdir.runpytest("-v", "--nunit-xml=" + outfile_pth)
     assert int(result.ret) == 1
-    assert "".join(result.stderr.lines) == ''
+    assert "".join(result.stderr.lines) == ""
     result.stdout.fnmatch_lines(["*test_one ERROR*"])
     result.stdout.fnmatch_lines(["*test_two XFAIL*"])


### PR DESCRIPTION
Added test to recreated error found in issue 
Fixes #55

[recreated_error.log](https://github.com/pytest-dev/pytest-nunit/files/9793730/recreated_error.log)
<img width="1792" alt="Screen Shot 2022-10-16 at 3 23 42 PM" src="https://user-images.githubusercontent.com/73356473/196021489-fdb8d96e-1ed9-4e7f-a0f0-644b70b2c9ef.png">
