### PR TITLE
Use regex instead escape method for !CDATA

### DIFF
--- a/pytest_nunit/attrs2xml.py
+++ b/pytest_nunit/attrs2xml.py
@@ -1,12 +1,13 @@
 import enum
+import re
 import xml.etree.ElementTree as ET
-from xml.sax.saxutils import escape
 
 
 class CdataComment(ET.Element):
     def __init__(self, text):
         super(CdataComment, self).__init__("CDATA!")
-        self.text = text.replace("\x1b","")
+        pattern = "\x1b\[[0-9;]*m"
+        self.text = re.sub(pattern,'',text)
 
 
 ET._original_serialize_xml = ET._serialize_xml

--- a/pytest_nunit/attrs2xml.py
+++ b/pytest_nunit/attrs2xml.py
@@ -6,8 +6,7 @@ import xml.etree.ElementTree as ET
 class CdataComment(ET.Element):
     def __init__(self, text):
         super(CdataComment, self).__init__("CDATA!")
-        pattern = "\x1b\[[0-9;]*m"
-        self.text = re.sub(pattern,'',text)
+        self.text = re.sub("\x1b\[[0-9;]*m",'',text)
 
 
 ET._original_serialize_xml = ET._serialize_xml

--- a/pytest_nunit/attrs2xml.py
+++ b/pytest_nunit/attrs2xml.py
@@ -6,7 +6,7 @@ from xml.sax.saxutils import escape
 class CdataComment(ET.Element):
     def __init__(self, text):
         super(CdataComment, self).__init__("CDATA!")
-        self.text = escape(text, {"\x1b": "&#x1b;"})
+        self.text = text.replace("\x1b","")
 
 
 ET._original_serialize_xml = ET._serialize_xml


### PR DESCRIPTION
Hi, and sorry for my English,

For CDATA in XML, "& , > , <" are allowed.
But escape method in xml.saxs.saxutils remove these characters.

So, I use regex to remove only code colors and now, the code of test is correct in test result in TFS.

BR,
Titi
