### PR TITLE
replace deprecated datetime.utcnow() functionality

### DIFF
--- a/pytest_nunit/plugin.py
+++ b/pytest_nunit/plugin.py
@@ -150,8 +150,8 @@ class _NunitNodeReporter:
                 "outcome": "",
             }
             self.nunit_xml.idrefindex += 1  # Inc. node id ref counter
-            r["start"] = datetime.utcnow()  # Will be overridden if called
-            r["stop"] = datetime.utcnow()  # Will be overridden if called
+            r["start"] = datetime.now(datetime.UTC)  # Will be overridden if called
+            r["stop"] = datetime.now(datetime.UTC)   # Will be overridden if called
             r["duration"] = 0  # Updated on teardown
             if testreport.outcome == "skipped":
                 log.debug("skipping : {0}".format(testreport.longrepr))
@@ -177,7 +177,7 @@ class _NunitNodeReporter:
             r["stack-trace"] = self.nunit_xml._getcrashline(testreport)
         elif testreport.when == "teardown":
             r = self.nunit_xml.cases[testreport.nodeid]
-            r["stop"] = datetime.utcnow()
+            r["stop"] = datetime.now(datetime.UTC) 
             r["duration"] = (
                 (r["stop"] - r["start"]).total_seconds() if r["call-report"] else 0
             )  # skipped.
@@ -335,7 +335,7 @@ class NunitXML:
 
     def pytest_sessionstart(self, *args):
         """Mark test session start time."""
-        self.suite_start_time = datetime.utcnow()
+        self.suite_start_time = datetime.now(datetime.UTC)
 
     def _getcrashline(self, rep):
         try:
@@ -396,7 +396,7 @@ class NunitXML:
         dirname = os.path.dirname(os.path.abspath(self.logfile))
         if not os.path.isdir(dirname):
             os.makedirs(dirname)
-        self.suite_stop_time = datetime.utcnow()
+        self.suite_stop_time = datetime.now(datetime.UTC) 
         self.suite_time_delta = (
             self.suite_stop_time - self.suite_start_time
         ).total_seconds()


### PR DESCRIPTION
datetime.utcnow() is deprecated in python3.12 Replacing it with `datetime.now(datetime.UTC)` will remove deprecation warnings.