### PR TITLE
Change locale.getdefaultlocale to getlocale

### DIFF
--- a/pytest_nunit/nunit.py
+++ b/pytest_nunit/nunit.py
@@ -116,7 +116,7 @@ def _format_filters(filters_):
 
 
 def _getlocale():
-    language_code = locale.getdefaultlocale()[0]
+    language_code = locale.getlocale(locale.LC_CTYPE)[0]
     if language_code:
         return language_code
     return "en-US"


### PR DESCRIPTION
Fix Deprecation warning in Python 3.11:

pytest_nunit\nunit.py:119: DeprecationWarning: Use setlocale(), getencoding() and getlocale() instead