### PR TITLE
Use lazy string formatting for logger

### DIFF
--- a/pytest_nunit/plugin.py
+++ b/pytest_nunit/plugin.py
@@ -130,7 +130,7 @@ class _NunitNodeReporter:
 
     def record_testreport(self, testreport):
         """Export to XML."""
-        log.debug("record_test_report:{0}".format(testreport))
+        log.debug("record_test_report:%s", testreport)
 
         if testreport.when == "setup":
             r = self.nunit_xml.cases[testreport.nodeid] = {
@@ -155,7 +155,7 @@ class _NunitNodeReporter:
             r["stop"] = datetime.now(timezone.utc)   # Will be overridden if called
             r["duration"] = 0  # Updated on teardown
             if testreport.outcome == "skipped":
-                log.debug("skipping : {0}".format(testreport.longrepr))
+                log.debug("skipping : %s", testreport.longrepr)
                 if (
                     isinstance(testreport.longrepr, tuple)
                     and len(testreport.longrepr) > 2
@@ -281,7 +281,7 @@ class NunitXML:
         self.show_username = show_username
         self.show_user_domain = show_user_domain
         self.attach_on = attach_on
-        logging.debug("Attach on criteria : {0}".format(attach_on))
+        log.debug("Attach on criteria : %s", attach_on)
         self.idrefindex = 100  # Create a unique ID counter
         self.filters = filters
 


### PR DESCRIPTION
This pull request primarily refactors the logging statements in the `pytest_nunit/plugin.py` file. The changes replace the usage of `format()` method for string formatting in the debug logs with the `%s` placeholder, which is a more preferred way for string formatting in logging.

Here are the key changes:

* `pytest_nunit/plugin.py` - `def __init__(self, nodeid, nunit_xml):`: Replaced the `format()` method with `%s` for string formatting in the debug log statement.
* `pytest_nunit/plugin.py` - `def record_testreport(self, testreport):`: Updated two debug log statements, replacing the `format()` method with `%s` for string formatting. [[1]](diffhunk://#diff-096b468d9014ebe6cf47756f851249d5e7813a1e856f44818ceb00fa67ffb6f1L158-R158) [[2]](diffhunk://#diff-096b468d9014ebe6cf47756f851249d5e7813a1e856f44818ceb00fa67ffb6f1L284-R284)

Fixes #68