### PR TITLE
Test Pytest 8.x series

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,8 +23,14 @@ jobs:
             pytest-version: "7.1.0"
           - python-version: "3.11"
             pytest-version: "7.1.0"
+          - python-version: "3.8"
+            pytest-version: "7.2.0"
           - python-version: "3.12"
             pytest-version: "7.2.0"
+          - python-version: "3.8"
+            pytest-version: "8.0.1"
+          - python-version: "3.12"
+            pytest-version: "8.0.1"
 
     steps:
     - uses: actions/checkout@v3

--- a/tox.ini
+++ b/tox.ini
@@ -9,6 +9,9 @@ envlist =
     py37-pytest{46,50,latest},
     py38-pytest{46,50,60,70,latest},
     py39-pytest{46,50,60,70,latest}
+    py310-pytest{70,80,latest}
+    py311-pytest{70,80,latest}
+    py312-pytest{70,80,latest}
 
 [testenv]
 commands = python -m pytest tests
@@ -18,6 +21,7 @@ deps =
     pytest50: pytest >=5.0.0, <6.0.0
     pytest60: pytest >=6.0.0, <7.0.0
     pytest70: pytest >=7.0.0, <8.0.0
+    pytest80: pytest >=8.0.0, <9.0.0
     pytestlatest: pytest >= 4.6.0
 
 [testenv:lint]


### PR DESCRIPTION
This pull request primarily focuses on updating the Python and pytest versions used in the project's continuous integration (CI) and testing environments. The changes include updating the Python versions in the GitHub Actions CI workflow, adding new Python and pytest versions to the tox environment list, and specifying the pytest dependencies for the new pytest versions in the tox configuration.

Updates to Python and pytest versions in CI workflow:

* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR26-R33): Python versions 3.8 and 3.12 were added to the GitHub Actions CI workflow, and pytest versions 7.2.0 and 8.0.1 were added to the corresponding Python versions.

Updates to tox environment list:

* [`tox.ini`](diffhunk://#diff-ef2cef9f88b4fe09ca3082140e67f5ad34fb65fb6e228f119d3812261ae51449R12-R14): Python versions 3.10, 3.11, and 3.12 were added to the tox environment list, along with pytest versions 7.0, 8.0, and the latest version for each Python version.

Updates to pytest dependencies in tox configuration:

* [`tox.ini`](diffhunk://#diff-ef2cef9f88b4fe09ca3082140e67f5ad34fb65fb6e228f119d3812261ae51449R24): A new pytest dependency for version 8.0 was added to the tox configuration.